### PR TITLE
2-to-configure-how-many-spaces-to-use-when-writing-the-json-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New option `indentSize` to customize how many space to use to write on the asset file.
+
 ## [0.1.1] 2020-10-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ yarn add --dev gulp-revisionner
 - [2. Customize the base path](#2-customize-the-base-path)
 - [3. Customize the name and the folder to write the manifest file](#3-customize-the-name-and-the-folder-to-write-the-manifest-file)
 - [4. Always override the manifest file with the new content](4-always-override-the-manifest-file-with-the-new-content)
+- [5. Customize the indent size of the written asset file](#5-customize-the-indent-size-of-the-written-asset-file)
 
 ### 1. Write a manifest file
 
@@ -171,6 +172,29 @@ const build = () =>
     .pipe(
       revisioner({
         eraseBeforeWriting: true,
+      })
+    )
+    .pipe(dest("public/css"));
+```
+
+### 5. Customize the indent size of the written asset file
+
+In this example, we will customize how many spaces to use when writting the asset file (useful if you need to follow your code conventions).
+
+By default, the indent size is set to 2.
+
+```js
+// gulpfile.js
+const { src, dest } = require("gulp");
+const sass = require("gulp-sass");
+const revisioner = require("gulp-revisioner");
+
+const build = () =>
+  src("assets/sass/**/*.sass")
+    .pipe(sass())
+    .pipe(
+      revisioner({
+        indentSize: 4,
       })
     )
     .pipe(dest("public/css"));

--- a/lib/IOptions.d.ts
+++ b/lib/IOptions.d.ts
@@ -18,4 +18,8 @@ export default interface IOptions {
      * Override the existing manifest without trying to keep the old content.
      */
     eraseBeforeWriting?: boolean;
+    /**
+     * Number of spaces to use to indent the JSON content. Default: 2.
+     */
+    indentSize?: number;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,13 @@ var crypto = require('crypto');
 var isBoolean = (function (element) { return element !== null && element !== undefined && element.constructor === Boolean; });
 
 /**
+ * Returns true if the variable is a Number, else returns false.
+ *
+ * @param {Any} element The variable to check.
+ */
+var isInteger = (function (element) { return element === parseInt(element, 10); });
+
+/**
  * Returns true if the element is an Object, else returns false.
  *
  * @param {Any} element The variable to check.
@@ -67,6 +74,14 @@ var checkOptions = (function (options) {
     }
     else {
         parsedOptions.eraseBeforeWriting = false;
+    }
+    if ("indentSize" in options) {
+        if (!isInteger(options.indentSize)) {
+            return new TypeError("Expected options.indentSize to be an integer Number.");
+        }
+    }
+    else {
+        parsedOptions.indentSize = 2;
     }
     return parsedOptions;
 });
@@ -129,8 +144,12 @@ var getRevisionValue = (function (filePath, baseUrl, fileContent) {
  *
  * @param {String} filePath The path to the file being revisioned.
  * @param {Object} json The JSON object that represents the revisioned paths.
+ * @param {Number} numberOfSpaces The number of spaces to use to indent the written JSON.
  */
-var writeJsonToFile = (function (filePath, json) { return fs.writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n"); });
+var writeJsonToFile = (function (filePath, json, numberOfSpaces) {
+    if (numberOfSpaces === void 0) { numberOfSpaces = 2; }
+    return fs.writeFileSync(filePath, JSON.stringify(json, null, numberOfSpaces) + "\n");
+});
 
 /**
  * Write the revisioned path to the manifest file.
@@ -150,7 +169,7 @@ var writeManifest = (function (file, options) {
     var manifestPath = path.join((_b = options.manifestDirectory) !== null && _b !== void 0 ? _b : "", (_c = options.manifestName) !== null && _c !== void 0 ? _c : "");
     var json = !options.eraseBeforeWriting && fs.existsSync(manifestPath) ? getJsonFromFile(manifestPath) : {};
     json[revisionKey] = revisionValue;
-    writeJsonToFile(manifestPath, json);
+    writeJsonToFile(manifestPath, json, options.indentSize);
     return null;
 });
 

--- a/lib/is-integer.d.ts
+++ b/lib/is-integer.d.ts
@@ -1,0 +1,7 @@
+declare const _default: (element: any) => boolean;
+/**
+ * Returns true if the variable is a Number, else returns false.
+ *
+ * @param {Any} element The variable to check.
+ */
+export default _default;

--- a/lib/write-json-to-file.d.ts
+++ b/lib/write-json-to-file.d.ts
@@ -1,9 +1,10 @@
 import IJson from "./IJson";
-declare const _default: (filePath: string, json: IJson) => void;
+declare const _default: (filePath: string, json: IJson, numberOfSpaces?: number) => void;
 /**
  * Write a json object as a string to the file.
  *
  * @param {String} filePath The path to the file being revisioned.
  * @param {Object} json The JSON object that represents the revisioned paths.
+ * @param {Number} numberOfSpaces The number of spaces to use to indent the written JSON.
  */
 export default _default;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "typescript": "4.*"
     },
     "scripts": {
-        "build": "ncu && rollup -c && tsc --declaration --emitDeclarationOnly --declarationDir lib src/*.ts",
+        "build": "ncu && rollup -c && tsc --declaration --emitDeclarationOnly --declarationDir lib src/index.ts",
         "test": "nyc mocha --require ts-node/register tests/**/*.ts",
         "release": "np"
     },

--- a/src/IOptions.ts
+++ b/src/IOptions.ts
@@ -21,4 +21,9 @@ export default interface IOptions {
      * Override the existing manifest without trying to keep the old content.
      */
     eraseBeforeWriting?: boolean;
+
+    /**
+     * Number of spaces to use to indent the JSON content. Default: 2.
+     */
+    indentSize?: number;
 };

--- a/src/is-integer.ts
+++ b/src/is-integer.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns true if the variable is a Number, else returns false.
+ *
+ * @param {Any} element The variable to check.
+ */
+export default (element: any): boolean => element === parseInt(element, 10);

--- a/src/parse-options.ts
+++ b/src/parse-options.ts
@@ -1,5 +1,6 @@
 import IOptions from "./IOptions";
 import isBoolean from "./is-boolean";
+import isInteger from "./is-integer";
 import isObject from "./is-object";
 import isString from "./is-string";
 
@@ -45,6 +46,14 @@ export default (options: IOptions): IOptions|Error => {
         }
     } else {
         parsedOptions.eraseBeforeWriting = false;
+    }
+
+    if ("indentSize" in options) {
+        if (!isInteger(options.indentSize)) {
+            return new TypeError("Expected options.indentSize to be an integer Number.");
+        }
+    } else {
+        parsedOptions.indentSize = 2;
     }
 
     return parsedOptions;

--- a/src/write-json-to-file.ts
+++ b/src/write-json-to-file.ts
@@ -6,5 +6,6 @@ import IJson from "./IJson";
  *
  * @param {String} filePath The path to the file being revisioned.
  * @param {Object} json The JSON object that represents the revisioned paths.
+ * @param {Number} numberOfSpaces The number of spaces to use to indent the written JSON.
  */
-export default (filePath: string, json: IJson): void => writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n");
+export default (filePath: string, json: IJson, numberOfSpaces = 2): void => writeFileSync(filePath, JSON.stringify(json, null, numberOfSpaces) + "\n");

--- a/src/write-manifest.ts
+++ b/src/write-manifest.ts
@@ -29,7 +29,7 @@ export default (file: IFile|string, options: IOptions): Error|null => {
 
     json[revisionKey] = revisionValue;
 
-    writeJsonToFile(manifestPath, json);
+    writeJsonToFile(manifestPath, json, options.indentSize);
 
     return null;
 };

--- a/tests/is-integer-test.ts
+++ b/tests/is-integer-test.ts
@@ -1,0 +1,11 @@
+import { it, describe } from "mocha";
+import { expect } from "chai";
+import isInteger from "../src/is-integer";
+
+describe("isInteger()", () => {
+    it("should return true if the variable is an integer", () => expect(isInteger(42)).to.be.true);
+
+    it("should return false if the variable is a float", () => expect(isInteger(42.42)).to.be.false);
+
+    it("should return false if the variable is not a number", () => expect(isInteger("42")).to.be.false);
+});

--- a/tests/parse-options-test.ts
+++ b/tests/parse-options-test.ts
@@ -10,6 +10,7 @@ describe("parseOptions()", () => {
             manifestDirectory: resolve(__dirname + "/../src"),
             manifestName: "manifest.json",
             eraseBeforeWriting: false,
+            indentSize: 2,
         });
     });
 
@@ -54,5 +55,14 @@ describe("parseOptions()", () => {
                 eraseBeforeWriting: 42,
             });
         }).to.throw("Expected options.eraseBeforeWriting to be a Boolean.");
+    });
+
+    it("should throw an exception if the options.indentSize is not a number", () => {
+        expect(() => {
+            throw parseOptions({
+                // @ts-ignore
+                indentSize: "42",
+            });
+        }).to.throw("Expected options.indentSize to be an integer Number");
     });
 });


### PR DESCRIPTION
## Added

- New option `indentSize` to customize how many spaces to use to indent the JSON asset file.

## Fixed

- Bug when the declaration dir command would produce an error at build time.

## Breaking

None.