### PR TITLE
3-bug-when-running-the-plugin-without-options-will-throw-an-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New option `indentSize` to customize how many space to use to write on the asset file.
 
+### Fixed
+
+- Calling the plugin without options will no longer throw an error.
+
 ## [0.1.1] 2020-10-01
 
 ### Fixed

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
 import { Transform } from "stream";
 import IOptions from "./IOptions";
-declare const _default: (options: IOptions) => Transform;
+declare const _default: (options?: IOptions) => Transform;
 /**
  * Write file path with cache busting query strings into a JSON manifest file.
  *

--- a/lib/index.js
+++ b/lib/index.js
@@ -182,6 +182,7 @@ var writeManifest = (function (file, options) {
  * @param {String} options.manifestName="manifest.json" The name of the manifest file.
  */
 var index = (function (options) {
+    if (options === void 0) { options = {}; }
     var parsedOptions = checkOptions(options);
     var transformStream = new stream.Transform({ objectMode: true });
     transformStream._transform = function (file, encoding, callback) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import writeManifest from "./write-manifest";
  * @param {String} options.manifestDirectory=__dirname The directory to store the manifest on (default on the current directory).
  * @param {String} options.manifestName="manifest.json" The name of the manifest file.
  */
-export default (options: IOptions): Transform => {
+export default (options: IOptions = {}): Transform => {
     const parsedOptions = checkOptions(options);
 
     const transformStream = new Transform({objectMode: true});


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when calling the plugin without parameter would throw an error.

## Breaking

None.