### PR TITLE
4-bug-when-running-the-command-will-write-the-file-on-the-library-folder-instead-of-the-current-working-directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Calling the plugin without options will no longer throw an error.
+- The JSON asset file will now correctly be written in the current directory where your gulpfile is working.
 
 ## [0.1.1] 2020-10-01
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var stream = require('stream');
+var process = require('process');
 var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
@@ -57,7 +58,7 @@ var checkOptions = (function (options) {
         }
     }
     else {
-        parsedOptions.manifestDirectory = __dirname;
+        parsedOptions.manifestDirectory = process.cwd();
     }
     if ("manifestName" in options) {
         if (!isString(options.manifestName)) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,10 @@ export default {
         exports: "default"
     },
     external: [
-        "stream","fs","path","crypto"
+        "stream",
+        "fs",
+        "path",
+        "crypto",
+        "process",
     ]
 }

--- a/src/parse-options.ts
+++ b/src/parse-options.ts
@@ -1,3 +1,4 @@
+import { cwd } from "process";
 import IOptions from "./IOptions";
 import isBoolean from "./is-boolean";
 import isInteger from "./is-integer";
@@ -29,7 +30,7 @@ export default (options: IOptions): IOptions|Error => {
             return new TypeError("Expected options.manifestDirectory to be a String.");
         }
     } else {
-        parsedOptions.manifestDirectory = __dirname;
+        parsedOptions.manifestDirectory = cwd();
     }
 
     if ("manifestName" in options) {

--- a/tests/parse-options-test.ts
+++ b/tests/parse-options-test.ts
@@ -7,7 +7,7 @@ describe("parseOptions()", () => {
     it("should fill the with the default values", () => {
         expect(parseOptions({})).to.be.deep.equal({
             baseUrl: "/",
-            manifestDirectory: resolve(__dirname + "/../src"),
+            manifestDirectory: resolve(__dirname + "/../"),
             manifestName: "manifest.json",
             eraseBeforeWriting: false,
             indentSize: 2,


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when building would write the JSON asset file in the library directory instead of the calling gulpfile directory.

## Breaking

None.